### PR TITLE
feat: unlock solidity version

### DIFF
--- a/src/ERC721K.sol
+++ b/src/ERC721K.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 error ERC721__ApprovalCallerNotOwnerNorApproved(address caller);
 error ERC721__ApproveToCaller();

--- a/src/test/ERC721K.t.sol
+++ b/src/test/ERC721K.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Fork of: https://github.com/Rari-Capital/solmate/blob/main/src/test/ERC721.t.sol
-pragma solidity 0.8.10;
+pragma solidity ^0.8.10;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {DSInvariantTest} from "solmate/test/utils/DSInvariantTest.sol";


### PR DESCRIPTION
I was trying to benchmark this implementation for other solc versions but couldn't because it is locked to solc 0.8.10. This change unlocks the specific solc version requirement and let your contract be be compiled by any solc version >=0.8.10 and < 0.9